### PR TITLE
Add grunt-file-creator to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-contrib-jade": "0.8.x",
     "grunt-contrib-sass": "0.7.x",
     "grunt-contrib-watch": "0.5.x",
+    "grunt-file-creator": "0.1.x",
     "grunt-preprocess": "^4.0.0",
     "grunt-rename": "^0.1.3",
     "grunt-shell-spawn": "0.3.x"


### PR DESCRIPTION
This is required by our Gruntfile. Without this, `npm start` throws an error.
