### PR TITLE
Implement sharding counter scheme for computing the total donations.

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -50,6 +50,7 @@ class AdminDashboardHandler(webapp2.RequestHandler):
       'missingUsers': [dict(email=user.email, amount=amt/100)
                        for user, amt in users],
       'totalMissing': sum(v for _, v in users)/100,
+      'shardedCounterTotal': model.ShardedCounter.get_count('TOTAL')/100,
     }))
 
   # Gets all the users with missing employer/occupation data who gave at least

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,6 +142,10 @@ class PledgeHandler(webapp2.RequestHandler):
     # Add thank you email to a task queue
     deferred.defer(send_thank_you, name or email, email,
                    pledge.url_nonce, amount, _queue="mail")
+
+    # Add to the total asynchronously.
+    deferred.defer(model.increment_donation_total, amount, _queue="incrementTotal")
+
     self.response.write('Ok.')
 
 

--- a/backend/queue.yaml
+++ b/backend/queue.yaml
@@ -2,3 +2,6 @@ queue:
 - name: mail
   # Max email rate for a paid account
   rate: 4900/m
+
+- name: incrementTotal
+  rate: 60/s

--- a/markup/admin-dashboard.jade.j2
+++ b/markup/admin-dashboard.jade.j2
@@ -25,4 +25,5 @@ html
               td {{user.amount}}
             {% endfor %}
         .col-md-4
-          h2 Something over here!
+          h2 Sharded Counter Total
+          p ${{shardedCounterTotal}}


### PR DESCRIPTION
https://developers.google.com/appengine/articles/sharding_counters

This change increments the counters, and stores all the pledges with
model_version=2 for tracking. We don't actually use the counters
yet. Once this is live and no more pledges are coming in without
model_version>=2, we'll count the total donations for pledges not
included in the counters, and manually add that.
