### PR TITLE
Tune the backup validation; require email, order the errors

### DIFF
--- a/assets/pledge.js
+++ b/assets/pledge.js
@@ -48,19 +48,22 @@ var validateForm = function() {
     var amount = $('#amount_input').val() || null;
 
 
-    if (!occ) {
+    if (!email) {
+      showError( "Please enter email");
+      return false;
+    } else if (!validateEmail(email)) {
+      showError("Please enter a valid email");
+      return false;
+    } else if (!occ) {
       showError( "Please enter occupation");
       return false;
     } else if (!emp) {
       showError( "Please enter employer");
       return false;
-    } else if (!email) {
-      showError("Sorry, we are having trouble accepting pledges right now.  Please come back in 10 minutes");
+    } else if (!amount) {
+      showError( "Please enter an amount");
       return false;
-    } else if (!validateEmail(email)) {
-      showError("Please enter a valid email");
-      return false;
-    } else if (amount && amount < 1) {
+    } else if (amount < 1) {
       showError( "Please enter an amount of $1 or more");
       return false;
     }


### PR DESCRIPTION
in visual order.

This is a minor fix; The Paypal button uses the 'backup' validation, and so it exposes a few bugs.  Need to supply an email, and the errors should come in order they appear on screen.
